### PR TITLE
chore: replace []string with strings.Builder

### DIFF
--- a/service/yahoo_finance_service.go
+++ b/service/yahoo_finance_service.go
@@ -93,17 +93,12 @@ func GetTicker(symbol string) (string, ErrorCode) {
 	if len(yahooData.QuoteResponse.Result) > 0 {
 		quote := yahooData.QuoteResponse.Result[0]
 
-		results := []string{
-			quote.LongName,
-			"Price: " + quote.Currency + " " + floatToString(quote.RegularMarketPrice),
-			"Last change: " + " " + floatToString(quote.RegularMarketChangePercent) + "%",
-		}
-		return strings.Join(results, "\n"), Ok
-	} else {
-		return "", Unknown
-	}
-}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%s\n", quote.LongName)
+		fmt.Fprintf(&sb, "Price: %s %.2f\n", quote.Currency, quote.RegularMarketPrice)
+		fmt.Fprintf(&sb, "Last change: %.2f%%", quote.RegularMarketChangePercent)
 
-func floatToString(floatingNumber float64) string {
-	return strconv.FormatFloat(floatingNumber, 'f', 2, 64)
+		return sb.String(), Ok
+	}
+	return "", Unknown
 }


### PR DESCRIPTION
That's a cool project that you just built! 🎉 

If you want to contact string, `strings.Builder` can be useful. It's even possible to re-use the same instance after assigning the result of `String()` by resetting it using `Reset()`.

Since it implements `io.Writer` it can be used with `fmt.Fprintf()` which makes dealing with floats super easy ([`%.2f`, etc](https://cheatography.com/gpascual/cheat-sheets/golang-fmt-printing/)). 👍 